### PR TITLE
Fix GO build

### DIFF
--- a/Chapter04/Exercise4.01/Dockerfile
+++ b/Chapter04/Exercise4.01/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:latest
 WORKDIR /myapp
 COPY welcome.go .
+RUN go mod init myapp
 RUN go build -o welcome .
 ENTRYPOINT ["./welcome"]
 


### PR DESCRIPTION
Now in the latest versions of go it is necessary to start a module. 